### PR TITLE
Improved type information with psalm annotations on query and command buses

### DIFF
--- a/src/CommandBusInterface.php
+++ b/src/CommandBusInterface.php
@@ -6,5 +6,11 @@ namespace Spiral\Cqrs;
 
 interface CommandBusInterface
 {
+    /**
+     * @template TResult
+     * @param CommandInterface<TResult> $command
+     *
+     * @return TResult
+     */
     public function dispatch(CommandInterface $command): mixed;
 }

--- a/src/CommandInterface.php
+++ b/src/CommandInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Cqrs;
 
+/**
+ * @template TResult
+ */
 interface CommandInterface
 {
 

--- a/src/QueryBusInterface.php
+++ b/src/QueryBusInterface.php
@@ -6,5 +6,11 @@ namespace Spiral\Cqrs;
 
 interface QueryBusInterface
 {
+    /**
+     * @template TResult
+     * @param QueryInterface<TResult> $query
+     *
+     * @return TResult
+     */
     public function ask(QueryInterface $query): mixed;
 }

--- a/src/QueryInterface.php
+++ b/src/QueryInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Spiral\Cqrs;
 
+/**
+ * @template TResult
+ */
 interface QueryInterface
 {
 


### PR DESCRIPTION
In this Pull Request, we have enriched the type information of query and command buses by integrating Psalm annotations. This enhancement facilitates developers by offering precise return type definitions for commands and queries.

Here's a snapshot of what has been done:

1. For commands, you can now clearly define the return type. Here is an example utilizing `@implements CommandInterface<...>` annotation:

```php
use Spiral\Cqrs\CommandInterface;

/**
 * @implements CommandInterface<StoreUserResult>
 */
final readonly class StoreUserCommand implements CommandInterface
{
    public function __construct(
        public string $username,
        public string $email,
    ) {
    }
}
```

2. Similarly, for queries, the return type can be defined as shown in the `UserListQuery` class example below:

```php
use Spiral\Cqrs\QueryInterface;

/**
 * @implements QueryInterface<UserListResult>
 */
final readonly class UserListQuery implements QueryInterface
{

}
```

With these annotations in place, your IDE will now provide suggestive autocomplete options, making the code interaction more intuitive and error-prone. 

Here are examples showing how IDE suggestions would appear post this update:

```php
$bus->ask(new UserListQuery())->...;
```

```php
$bus->dispatch(new StoreUserCommand(...))->...;
```

![image](https://github.com/spiral-packages/cqrs/assets/773481/aaa3a6bf-d426-46ba-ab65-ab05d3ece5de)

This update aims to streamline the development process by providing clearer, type-informed interactions within the codebase.